### PR TITLE
Implemented proxy to backend

### DIFF
--- a/frontend/apps/cruzcal/project.json
+++ b/frontend/apps/cruzcal/project.json
@@ -19,7 +19,8 @@
       "executor": "@nrwl/next:server",
       "options": {
         "buildTarget": "cruzcal:build",
-        "dev": true
+        "dev": true,
+        "proxyConfig": "apps/cruzcal/proxy.conf.json"
       },
       "configurations": {
         "production": {

--- a/frontend/apps/cruzcal/proxy.conf.json
+++ b/frontend/apps/cruzcal/proxy.conf.json
@@ -1,0 +1,7 @@
+{
+  "/api": {
+    "target": "http://localhost:3010",
+    "secure": false,
+    "pathRewrite": { "^/api": "" }
+  }
+}


### PR DESCRIPTION
Can now query backend API running on port 3010.

Converts paths of form '/api/:path' to call '/:path' on the backend server.

For example, fetch('/api/terms') would call the GET /terms endpoint. 