### PR TITLE
Incremental course query

### DIFF
--- a/backend/api/openapi.json
+++ b/backend/api/openapi.json
@@ -15,15 +15,114 @@
       "get": {
         "description": "Return information for all available terms",
         "responses": {
-          "201": {
+          "200": {
             "description": "Successfully returned all available terms.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TermInfo"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TermInfo"
+                  }
                 }
               }
             }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subjects": {
+      "get": {
+        "description": "Get available subjects",
+        "parameters": [
+          {
+            "description": "Optional query parameter to filter by a term",
+            "in": "query",
+            "name": "term",
+            "schema": {
+              "$ref": "#/components/schemas/TermCode"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned subjects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Subject"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No subjects found"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/courses": {
+      "get": {
+        "description": "Get available courses",
+        "parameters": [
+          {
+            "description": "Required query parameter to filter by a term",
+            "required": true,
+            "in": "query",
+            "name": "term",
+            "schema": {
+              "$ref": "#/components/schemas/TermCode"
+            }
+          },
+          {
+            "description": "Required query parameter to filter by a subject",
+            "required": true,
+            "in": "query",
+            "name": "subject",
+            "schema": {
+              "$ref": "#/components/schemas/Subject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned courses",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CourseInfo"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No courses found"
           },
           "default": {
             "description": "Unexpected error",
@@ -106,6 +205,10 @@
         "type": "number",
         "example": 2222
       },
+      "Subject": {
+        "type": "string",
+        "example": "CSE"
+      },
       "TermInfo": {
         "type": "object",
         "additionalProperties": false,
@@ -179,16 +282,19 @@
       "CourseInfo": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["courseName", "lectures", "professor"],
+        "required": ["name", "lectures", "professor"],
         "properties": {
-          "courseName": {
+          "name": {
             "type": "string"
           },
           "professor": {
             "type": "string"
           },
           "lectures": {
-            "$ref": "#/components/schemas/LectureInfo"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LectureInfo"
+            }
           }
         }
       },

--- a/backend/initdb/index.js
+++ b/backend/initdb/index.js
@@ -1,3 +1,5 @@
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 require('dotenv').config();
 const {db} = require('../src/db/index');
-require('./fetch')(db);
+require('./fetch')(db, reset = true);

--- a/backend/src/__tests__/common.js
+++ b/backend/src/__tests__/common.js
@@ -56,7 +56,7 @@ exports.courses = [
     subject: 'CSE',
     coursenum: '115A',
     professor: 'Jullig,R.K.',
-    lectures: {
+    lectures: [{
       location: 'J Baskin Engr 152',
       times: [
         {
@@ -75,7 +75,7 @@ exports.courses = [
           end: '09:05',
         },
       ],
-    },
+    }],
     termcode: 2222,
   },
   {
@@ -84,7 +84,7 @@ exports.courses = [
     subject: 'AM',
     coursenum: '10',
     professor: 'Jonsson,V.',
-    lectures: {
+    lectures: [{
       location: 'Humn Lecture Hall',
       times: [
         {
@@ -98,7 +98,7 @@ exports.courses = [
           end: '13:15',
         },
       ],
-    },
+    }],
     termcode: 2220,
   },
 ];

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -27,7 +27,19 @@ app.use(
 // Routes
 
 app.get('/terms', routes.getTerms);
+app.get('/subjects', routes.getSubjects); // e.g. /subjects?term=2222
+app.get('/courses', routes.getCourses); // e.g. /courses?term=2222&subject=CSE
 app.post('/schedule', routes.genSchedule);
 app.post('/calendar', routes.genCalendar);
+
+app.use((err, req, res, next) => {
+  const error = {
+    // For unexpected errors with no status during dev
+    status: err.status || 500,
+    message: err.message,
+    errors: err.errors,
+  };
+  res.status(error.status).send(error);
+});
 
 module.exports = app;

--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -27,9 +27,7 @@ exports.getCourses = async (req, res) => {
 };
 
 exports.getTerms = async (req, res) => {
-  const terms = (await getAllTerms()).map(({code, name, start, end}) => (
-    {code, name, date: {start, end}}
-  ));
+  const terms = (await getAllTerms()).map(formatTerm);
   res.json(terms);
 };
 

--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -1,7 +1,36 @@
-const {getAllTerms, getTermByCode, getCourseByID} = require('./db');
+const {
+  getAllTerms,
+  getTermByCode,
+  getCourseByID,
+  getUniqueSubjects,
+  getAllCourses,
+} = require('./db');
+
+exports.getSubjects = async (req, res) => {
+  const {term: termcode} = req.query;
+  const conditions = termcode ? {termcode} : {};
+
+  const rows = await getUniqueSubjects(conditions);
+
+  if (rows.length === 0) res.sendStatus(404);
+  else res.json(rows.map(({subject}) => subject));
+};
+
+exports.getCourses = async (req, res) => {
+  const {term: termcode, subject} = req.query;
+  const conditions = {termcode, subject};
+
+  const rows = await getAllCourses(conditions);
+
+  if (rows.length === 0) res.sendStatus(404);
+  else res.json(rows.map(formatCourse));
+};
 
 exports.getTerms = async (req, res) => {
-  res.json(await getAllTerms());
+  const terms = (await getAllTerms()).map(({code, name, start, end}) => (
+    {code, name, date: {start, end}}
+  ));
+  res.json(terms);
 };
 
 exports.genSchedule = async (req, res) => {
@@ -14,10 +43,10 @@ exports.genSchedule = async (req, res) => {
   const foundCourses = [];
   for (const course of courses) {
     const found = await getCourseByID(termCode, course.courseID);
-    const formattedCourse = formatCourse(found);
     if (found == null) {
       return res.sendStatus(404);
     }
+    const formattedCourse = formatCourse(found);
     foundCourses.push(formattedCourse);
   }
   res.status(201).json({term: formattedTerm, courses: foundCourses});
@@ -28,7 +57,7 @@ exports.genCalendar = async (req, res) => {};
 // Helpers
 const formatCourse = (courseObj) => {
   const courseInfo = {
-    courseName: courseObj.name,
+    name: courseObj.name,
     professor: courseObj.professor,
     lectures: courseObj.lectures,
   };
@@ -46,28 +75,4 @@ const formatTerm = (termObj) => {
   };
   return termInfo;
 };
-const getIdentifierType = (identifier) => {
-  identifier = identifier.toLowerCase();
-  // Regex for subject and number, e.g. cse130, cse 130, cse 115a
-  const subjectAndNumReg = /[a-z]{2,}[\s-]*?\d{1,3}[\s-]*?\w{1}?/;
-  // Regex for course number, e.g. 70071
-  const courseNumReg = /\d{5}/;
-  if (subjectAndNumReg.test(identifier)) {
-    return 'subjectAndNum';
-  } else if (courseNumReg.test(identifier)) {
-    return 'courseNum';
-  }
-  return 'courseName';
-};
 
-// eslint-disable-next-line no-unused-vars
-const processIdentifier = (identifier) => {
-  const identifierType = getIdentifierType(identifier);
-  if (identifierType === 'subjectAndNum') {
-    identifier = identifier.replace(/ /g, '');
-  }
-  return {
-    identifier,
-    identifierType,
-  };
-};

--- a/backend/static-db.json
+++ b/backend/static-db.json
@@ -146,7 +146,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -160,7 +160,21 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
+        }
+      ],
+      "termcode": 2224
+    },
+    {
+      "name": "Digital Video",
+      "refnum": 71371,
+      "subject": "ART",
+      "coursenum": "104",
+      "professor": "Staff",
+      "lectures": [
+        {
+          "location": "Online",
+          "times": []
         }
       ],
       "termcode": 2224
@@ -174,7 +188,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -238,7 +252,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -253,6 +267,11 @@
         {
           "location": "E Baskin I200",
           "times": [
+            {
+              "day": "Tuesday",
+              "start": "11:00",
+              "end": "16:30"
+            },
             {
               "day": "Thursday",
               "start": "11:00",
@@ -272,7 +291,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -286,7 +305,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -375,7 +394,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -494,7 +513,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -592,7 +611,7 @@
       "professor": "Jullig,R.K.",
       "lectures": [
         {
-          "location": "Thim Lecture 001",
+          "location": "PhysSciences 110",
           "times": [
             {
               "day": "Monday",
@@ -618,7 +637,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -632,7 +651,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -671,7 +690,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -735,7 +754,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -745,7 +764,7 @@
       "refnum": 70987,
       "subject": "ECE",
       "coursenum": "171",
-      "professor": "Staff",
+      "professor": "Hurtarte,J.S.",
       "lectures": [
         {
           "location": "J Bask Aud 101",
@@ -774,7 +793,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -863,7 +882,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -877,7 +896,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -891,7 +910,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -930,7 +949,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -944,7 +963,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -1133,7 +1152,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -1197,7 +1216,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -1300,7 +1319,7 @@
       "professor": "Ratnaparkhi,A.",
       "lectures": [
         {
-          "location": null,
+          "location": "SiliconValleyCtr",
           "times": [
             {
               "day": "Tuesday",
@@ -1351,7 +1370,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -1390,7 +1409,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -1404,7 +1423,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -1418,7 +1437,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -1432,7 +1451,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -1446,7 +1465,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -1460,7 +1479,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -1474,7 +1493,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -1488,7 +1507,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -1502,7 +1521,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -1570,7 +1589,7 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": "J Baskin Engr 165",
+          "location": "Thimann Lab 239",
           "times": [
             {
               "day": "Wednesday",
@@ -1646,7 +1665,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -1685,7 +1704,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -1729,7 +1748,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -1742,8 +1761,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "Remote Instruction",
+          "times": []
         }
       ],
       "termcode": 2224
@@ -1756,8 +1775,19 @@
       "professor": "Mehta,R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "CoastBio 110",
+          "times": [
+            {
+              "day": "Tuesday",
+              "start": "09:00",
+              "end": "12:30"
+            },
+            {
+              "day": "Thursday",
+              "start": "09:00",
+              "end": "12:30"
+            }
+          ]
         }
       ],
       "termcode": 2224
@@ -1795,7 +1825,7 @@
       "professor": "Voss,K.M.",
       "lectures": [
         {
-          "location": null,
+          "location": "CoastBio 110",
           "times": [
             {
               "day": "Tuesday",
@@ -1821,7 +1851,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -1929,7 +1959,7 @@
       "professor": "Jurica,M.S.",
       "lectures": [
         {
-          "location": "Earth&Marine B214",
+          "location": "Sci & Engr Library 206",
           "times": [
             {
               "day": "Monday",
@@ -2185,7 +2215,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -2199,7 +2229,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -2213,7 +2243,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -2412,7 +2442,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -2501,7 +2531,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -2515,7 +2545,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -2529,7 +2559,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -2567,8 +2597,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2224
@@ -2637,7 +2667,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -2651,7 +2681,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -2686,7 +2716,7 @@
       "refnum": 71275,
       "subject": "CRES",
       "coursenum": "188B",
-      "professor": "Staff",
+      "professor": "Johnson,T.M.",
       "lectures": [
         {
           "location": "Remote Instruction",
@@ -2711,11 +2741,11 @@
       "refnum": 71334,
       "subject": "CRES",
       "coursenum": "188S",
-      "professor": "Staff",
+      "professor": "Komori,J.",
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -2729,7 +2759,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -2743,7 +2773,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -2757,7 +2787,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -2796,7 +2826,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -2810,7 +2840,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -2824,7 +2854,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -2908,7 +2938,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -2921,8 +2951,19 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "Remote Instruction",
+          "times": [
+            {
+              "day": "Tuesday",
+              "start": "09:50",
+              "end": "11:25"
+            },
+            {
+              "day": "Thursday",
+              "start": "09:50",
+              "end": "11:25"
+            }
+          ]
         }
       ],
       "termcode": 2224
@@ -2936,7 +2977,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -2949,7 +2990,7 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
+          "location": "",
           "times": [
             {
               "day": "Tuesday",
@@ -2974,8 +3015,19 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "Remote Instruction",
+          "times": [
+            {
+              "day": "Tuesday",
+              "start": "09:00",
+              "end": "12:30"
+            },
+            {
+              "day": "Thursday",
+              "start": "09:00",
+              "end": "12:30"
+            }
+          ]
         }
       ],
       "termcode": 2224
@@ -2989,7 +3041,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -3003,7 +3055,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -3038,11 +3090,11 @@
       "refnum": 71368,
       "subject": "EART",
       "coursenum": "189B",
-      "professor": "Staff",
+      "professor": "Finnegan,N.J.",
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -3081,7 +3133,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -3095,7 +3147,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -3134,7 +3186,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -3148,7 +3200,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -3158,11 +3210,11 @@
       "refnum": 71260,
       "subject": "ECON",
       "coursenum": "20",
-      "professor": "Staff",
+      "professor": "Gonzalez,J.H.",
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -3201,7 +3253,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -3390,7 +3442,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -3479,7 +3531,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -3593,7 +3645,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -3632,7 +3684,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -3670,8 +3722,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2224
@@ -3684,7 +3736,7 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
+          "location": "",
           "times": [
             {
               "day": "Tuesday",
@@ -3779,7 +3831,7 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
+          "location": "",
           "times": [
             {
               "day": "Monday",
@@ -3799,7 +3851,7 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
+          "location": "",
           "times": [
             {
               "day": "Monday",
@@ -3819,7 +3871,7 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
+          "location": "",
           "times": [
             {
               "day": "Wednesday",
@@ -3839,7 +3891,7 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
+          "location": "",
           "times": [
             {
               "day": "Wednesday",
@@ -3859,7 +3911,7 @@
       "professor": "Johnston,C.M.",
       "lectures": [
         {
-          "location": null,
+          "location": "",
           "times": [
             {
               "day": "Tuesday",
@@ -3895,7 +3947,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -3909,7 +3961,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -3968,7 +4020,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4082,7 +4134,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4096,7 +4148,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4135,7 +4187,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4174,7 +4226,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4213,7 +4265,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4223,7 +4275,7 @@
       "refnum": 71361,
       "subject": "FILM",
       "coursenum": "150",
-      "professor": "Staff",
+      "professor": "V.,N.",
       "lectures": [
         {
           "location": "Remote Instruction",
@@ -4252,7 +4304,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4266,7 +4318,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4360,7 +4412,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4374,7 +4426,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4388,7 +4440,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4447,7 +4499,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4511,7 +4563,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4525,7 +4577,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4564,7 +4616,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4578,7 +4630,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4592,7 +4644,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4606,7 +4658,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4616,11 +4668,11 @@
       "refnum": 71224,
       "subject": "KRSG",
       "coursenum": "1T",
-      "professor": "Staff",
+      "professor": "Gauger,J.",
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4726,6 +4778,20 @@
       "termcode": 2224
     },
     {
+      "name": "Transfer Success",
+      "refnum": 71370,
+      "subject": "KRSG",
+      "coursenum": "25",
+      "professor": "Staff",
+      "lectures": [
+        {
+          "location": "TBD In Person",
+          "times": []
+        }
+      ],
+      "termcode": 2224
+    },
+    {
       "name": "Prison Narratives",
       "refnum": 71228,
       "subject": "KRSG",
@@ -4734,7 +4800,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4788,7 +4854,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4802,7 +4868,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4816,7 +4882,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4855,7 +4921,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4869,7 +4935,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4883,7 +4949,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4922,7 +4988,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4936,7 +5002,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -4950,7 +5016,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -5064,7 +5130,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -5103,7 +5169,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -5117,7 +5183,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -5147,11 +5213,11 @@
       "refnum": 71365,
       "subject": "LGST",
       "coursenum": "188B",
-      "professor": "Staff",
+      "professor": "Garcia,M.X.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "Remote Instruction",
+          "times": []
         }
       ],
       "termcode": 2224
@@ -5240,7 +5306,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -5254,7 +5320,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -5289,7 +5355,7 @@
       "refnum": 70186,
       "subject": "LING",
       "coursenum": "131",
-      "professor": "Staff",
+      "professor": "Ostrove,J.H.",
       "lectures": [
         {
           "location": "Remote Instruction",
@@ -5394,7 +5460,7 @@
       "refnum": 70005,
       "subject": "MATH",
       "coursenum": "3",
-      "professor": "Louis,M.",
+      "professor": "Tessner,A.C.",
       "lectures": [
         {
           "location": "Remote Instruction",
@@ -5424,7 +5490,7 @@
       "refnum": 70243,
       "subject": "MATH",
       "coursenum": "3",
-      "professor": "Tessner,A.C.",
+      "professor": "Louis,M.",
       "lectures": [
         {
           "location": "Remote Instruction",
@@ -5578,7 +5644,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -5592,7 +5658,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -5606,7 +5672,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -5620,7 +5686,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -5754,7 +5820,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -5768,7 +5834,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -5782,7 +5848,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -5796,7 +5862,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -6191,11 +6257,11 @@
       "refnum": 70174,
       "subject": "MATH",
       "coursenum": "194",
-      "professor": "Staff",
+      "professor": "Ginzburg,V.",
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -6209,7 +6275,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -6248,7 +6314,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -6417,7 +6483,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -6427,7 +6493,7 @@
       "refnum": 70094,
       "subject": "MUSC",
       "coursenum": "11D",
-      "professor": "Staff",
+      "professor": "Lindsey,M.P.",
       "lectures": [
         {
           "location": "Music Center 131",
@@ -6456,7 +6522,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -6575,7 +6641,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -6644,7 +6710,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -6658,7 +6724,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -6672,7 +6738,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -6689,12 +6755,12 @@
           "times": [
             {
               "day": "Tuesday",
-              "start": "08:30",
+              "start": "09:00",
               "end": "12:00"
             },
             {
               "day": "Thursday",
-              "start": "08:30",
+              "start": "09:00",
               "end": "12:00"
             }
           ]
@@ -6711,7 +6777,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -6721,7 +6787,7 @@
       "refnum": 70202,
       "subject": "OAKS",
       "coursenum": "155",
-      "professor": "Staff",
+      "professor": "Raja,F.",
       "lectures": [
         {
           "location": "Oakes Acad 102",
@@ -6749,8 +6815,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "Remote Instruction",
+          "times": []
         }
       ],
       "termcode": 2224
@@ -6789,7 +6855,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -6828,7 +6894,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -6922,7 +6988,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -6985,7 +7051,7 @@
       "professor": "Johnson,R.P.",
       "lectures": [
         {
-          "location": "Humn Lecture Hall",
+          "location": "Thim Lecture 001",
           "times": [
             {
               "day": "Monday",
@@ -7325,17 +7391,17 @@
       "professor": "Powell,R.A.",
       "lectures": [
         {
-          "location": "PhysSciences 114",
+          "location": "Engineer 2 194",
           "times": [
             {
               "day": "Monday",
               "start": "13:00",
-              "end": "16:30"
+              "end": "16:00"
             },
             {
               "day": "Wednesday",
               "start": "13:00",
-              "end": "16:30"
+              "end": "16:00"
             }
           ]
         }
@@ -7370,7 +7436,7 @@
       "professor": "Snickars,E.S.",
       "lectures": [
         {
-          "location": null,
+          "location": "",
           "times": [
             {
               "day": "Tuesday",
@@ -7421,7 +7487,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -7434,7 +7500,7 @@
       "professor": "Wasserstrom,A.",
       "lectures": [
         {
-          "location": null,
+          "location": "",
           "times": [
             {
               "day": "Tuesday",
@@ -7460,7 +7526,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -7474,7 +7540,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -7854,7 +7920,7 @@
       "refnum": 71284,
       "subject": "PSYC",
       "coursenum": "122",
-      "professor": "Staff",
+      "professor": "Arcos,K.",
       "lectures": [
         {
           "location": "Remote Instruction",
@@ -8158,7 +8224,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -8172,7 +8238,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -8257,7 +8323,7 @@
       "refnum": 70143,
       "subject": "SOCY",
       "coursenum": "114",
-      "professor": "Staff",
+      "professor": "Domhoff,J.J.",
       "lectures": [
         {
           "location": "Engineer 2 192",
@@ -8286,7 +8352,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -8300,7 +8366,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -8314,7 +8380,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -8328,7 +8394,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -8342,7 +8408,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -8460,8 +8526,8 @@
       "professor": "Wang,Q.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2224
@@ -8475,7 +8541,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -8489,7 +8555,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -8503,7 +8569,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -8617,7 +8683,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -8656,7 +8722,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -8795,7 +8861,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -8859,7 +8925,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -8873,7 +8939,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -8887,7 +8953,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -8901,7 +8967,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -8915,7 +8981,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -9000,11 +9066,11 @@
       "refnum": 70990,
       "subject": "WRIT",
       "coursenum": "2",
-      "professor": "Staff",
+      "professor": "Osborne,B.",
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -9014,11 +9080,11 @@
       "refnum": 71002,
       "subject": "WRIT",
       "coursenum": "2",
-      "professor": "Staff",
+      "professor": "Perera,N.R.",
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -9028,11 +9094,11 @@
       "refnum": 71003,
       "subject": "WRIT",
       "coursenum": "2",
-      "professor": "Staff",
+      "professor": "Perera,N.R.",
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -9046,7 +9112,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -9060,7 +9126,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -9074,7 +9140,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -9088,7 +9154,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2224
@@ -9471,8 +9537,8 @@
       "professor": "Garaud,P.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -9596,7 +9662,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -9730,7 +9796,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -10044,7 +10110,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -10058,7 +10124,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -10411,8 +10477,8 @@
       "professor": "Haussler,D.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -10425,8 +10491,8 @@
       "professor": "Dubois,R.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -10439,8 +10505,8 @@
       "professor": "Green,R.E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -10454,7 +10520,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -10467,8 +10533,8 @@
       "professor": "Haussler,D.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -10481,8 +10547,8 @@
       "professor": "Paten,B.J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -10495,8 +10561,8 @@
       "professor": "Lowe,T.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -10509,8 +10575,8 @@
       "professor": "Brooks,A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -10523,8 +10589,8 @@
       "professor": "Pourmand,N.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -10537,8 +10603,8 @@
       "professor": "Kim,D.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -10551,8 +10617,8 @@
       "professor": "Stuart,J.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -10565,8 +10631,8 @@
       "professor": "Vollmers,C.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -10579,8 +10645,8 @@
       "professor": "Corbett-Detig,R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -10723,8 +10789,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -10887,8 +10953,8 @@
       "professor": "Beamer,S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -11476,8 +11542,8 @@
       "professor": "Graziani,R.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -11521,7 +11587,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -11974,8 +12040,8 @@
       "professor": "Guthaus,M.R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -11988,8 +12054,8 @@
       "professor": "Obraczka,K.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -12002,8 +12068,8 @@
       "professor": "Qian,C.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -12016,8 +12082,8 @@
       "professor": "Kuper,L.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -12030,8 +12096,8 @@
       "professor": "Renau Ardevol,J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -12044,8 +12110,8 @@
       "professor": "Maltzahn,C.G.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -12058,8 +12124,8 @@
       "professor": "Litz,H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -12072,8 +12138,8 @@
       "professor": "Manduchi,R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -12086,8 +12152,8 @@
       "professor": "Alvaro,P.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -12205,8 +12271,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -12220,7 +12286,7 @@
       "lectures": [
         {
           "location": "Ocean Health 118",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -12233,8 +12299,8 @@
       "professor": "Griggs,G.B.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -12293,7 +12359,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -12392,7 +12458,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -12531,7 +12597,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -12595,7 +12661,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -12639,7 +12705,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -12738,7 +12804,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -12851,8 +12917,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -13046,7 +13112,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -13109,8 +13175,8 @@
       "professor": "Rolandi,M.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -13123,8 +13189,8 @@
       "professor": "Milutinovic,D.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -13137,8 +13203,8 @@
       "professor": "Teodorescu,M.S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -13151,8 +13217,8 @@
       "professor": "Elkaim,G.H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -13165,8 +13231,8 @@
       "professor": "Chen,Y.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -13179,8 +13245,8 @@
       "professor": "Yanik,A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -13193,8 +13259,8 @@
       "professor": "Schmidt,H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -13207,8 +13273,8 @@
       "professor": "Zhang,Y.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -13387,7 +13453,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -13401,7 +13467,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -13415,7 +13481,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -13959,7 +14025,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -15067,8 +15133,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -15197,7 +15263,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -15380,8 +15446,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -15395,7 +15461,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -15409,7 +15475,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -15548,7 +15614,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -15587,7 +15653,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -15840,8 +15906,8 @@
       "professor": "Fehren-Schmitz,L.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -15934,8 +16000,8 @@
       "professor": "Oelze,V.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -16139,7 +16205,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -16287,8 +16353,8 @@
       "professor": "Gillette,K.L.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -16791,8 +16857,8 @@
       "professor": "Clabuesch,S.R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17251,7 +17317,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17339,8 +17405,8 @@
       "professor": "Croll,D.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17353,8 +17419,8 @@
       "professor": "Dayton,G.H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17367,8 +17433,8 @@
       "professor": "Dayton,G.H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17381,8 +17447,8 @@
       "professor": "Dayton,G.H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17440,8 +17506,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17544,8 +17610,8 @@
       "professor": "Carr,M.H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17558,8 +17624,8 @@
       "professor": "Bernardi,G.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17572,8 +17638,8 @@
       "professor": "Costa,D.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17586,8 +17652,8 @@
       "professor": "Kroeker,K.J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17600,8 +17666,8 @@
       "professor": "Palkovacs,E.P.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17614,8 +17680,8 @@
       "professor": "Alonzo,S.H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17628,8 +17694,8 @@
       "professor": "Mehta,R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17642,8 +17708,8 @@
       "professor": "Kilpatrick,A.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17656,8 +17722,8 @@
       "professor": "Kay,K.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17670,8 +17736,8 @@
       "professor": "Lyon,B.E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17684,8 +17750,8 @@
       "professor": "Croll,D.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17698,8 +17764,8 @@
       "professor": "Pittermann,J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17712,8 +17778,8 @@
       "professor": "Parker,I.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17726,8 +17792,8 @@
       "professor": "Pogson,G.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17740,8 +17806,8 @@
       "professor": "Raimondi,P.T.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17754,8 +17820,8 @@
       "professor": "Shapiro,B.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17768,8 +17834,8 @@
       "professor": "Potts,D.C.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17782,8 +17848,8 @@
       "professor": "Sinervo,B.R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17796,8 +17862,8 @@
       "professor": "Williams,T.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17810,8 +17876,8 @@
       "professor": "Beltran,R.S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17824,8 +17890,8 @@
       "professor": "Zavaleta,E.S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -17838,8 +17904,8 @@
       "professor": "Shapiro,B.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18118,7 +18184,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18407,7 +18473,7 @@
       "lectures": [
         {
           "location": "Remote Meeting",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18505,8 +18571,8 @@
       "professor": "Feldheim,D.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18639,8 +18705,8 @@
       "professor": "Ares,M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18653,8 +18719,8 @@
       "professor": "Boeger,H.H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18667,8 +18733,8 @@
       "professor": "Chen,B.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18681,8 +18747,8 @@
       "professor": "Zahler,A.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18695,8 +18761,8 @@
       "professor": "Bhalla,N.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18709,8 +18775,8 @@
       "professor": "Feldheim,D.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18723,8 +18789,8 @@
       "professor": "Ackman,J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18737,8 +18803,8 @@
       "professor": "Hartzog,G.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18751,8 +18817,8 @@
       "professor": "Kamakaka,R.T.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18765,8 +18831,8 @@
       "professor": "Jurica,M.S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18779,8 +18845,8 @@
       "professor": "Kellogg,D.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18793,8 +18859,8 @@
       "professor": "Hinck,L.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18807,8 +18873,8 @@
       "professor": "Sanford,J.R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18821,8 +18887,8 @@
       "professor": "Carpenter,S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18835,8 +18901,8 @@
       "professor": "Arribere,J.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18849,8 +18915,8 @@
       "professor": "Greider,C.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18863,8 +18929,8 @@
       "professor": "Ward,J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18877,8 +18943,8 @@
       "professor": "Strome,S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18891,8 +18957,8 @@
       "professor": "Sikandar,S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18905,8 +18971,8 @@
       "professor": "Sullivan,W.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18919,8 +18985,8 @@
       "professor": "Morozova,O.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18933,8 +18999,8 @@
       "professor": "Kim,E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18947,8 +19013,8 @@
       "professor": "Sharma,U.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18961,8 +19027,8 @@
       "professor": "Zuo,Y.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -18975,8 +19041,8 @@
       "professor": "Wang,Z.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -19139,8 +19205,8 @@
       "professor": "Roland,R.E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -19153,8 +19219,8 @@
       "professor": "Roland,R.E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -19512,8 +19578,8 @@
       "professor": "Braslau,R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -19526,8 +19592,8 @@
       "professor": "Holman,T.R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -19540,8 +19606,8 @@
       "professor": "Oliver,S.R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -19554,8 +19620,8 @@
       "professor": "Crews,P.O.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -19568,8 +19634,8 @@
       "professor": "Mascharak,P.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -19582,8 +19648,8 @@
       "professor": "Sanchez,L.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -19717,7 +19783,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -19750,8 +19816,8 @@
       "professor": "Beckett,L.K.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -19844,8 +19910,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -19933,8 +19999,8 @@
       "professor": "Guthman,J.H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -20033,7 +20099,7 @@
       "lectures": [
         {
           "location": "Remote Meeting",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -20172,7 +20238,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -20350,8 +20416,8 @@
       "professor": "Forbes,A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -20364,8 +20430,8 @@
       "professor": "Smith,A.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -20378,8 +20444,8 @@
       "professor": "Isbister,K.C.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -20392,8 +20458,8 @@
       "professor": "Kurniawan,S.H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -20406,8 +20472,8 @@
       "professor": "Seif El-Nasr,M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -20420,8 +20486,8 @@
       "professor": "Lee,D.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -20434,8 +20500,8 @@
       "professor": "Altice,N.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -20448,8 +20514,8 @@
       "professor": "Mateas,M.J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -20462,8 +20528,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -20607,7 +20673,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -21070,8 +21136,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -21175,7 +21241,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -21213,8 +21279,8 @@
       "professor": "Favaloro,T.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -21383,7 +21449,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -21396,8 +21462,8 @@
       "professor": "Hester,K.E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -21430,8 +21496,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -21444,8 +21510,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -21458,8 +21524,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -21708,7 +21774,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -22001,8 +22067,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -22015,8 +22081,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -22029,8 +22095,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -22223,8 +22289,8 @@
       "professor": "Finnegan,N.J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -22237,8 +22303,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -22312,7 +22378,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -22406,7 +22472,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -22510,7 +22576,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -22869,7 +22935,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -23038,7 +23104,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -23866,8 +23932,8 @@
       "professor": "Wilson,J.B.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -23880,8 +23946,8 @@
       "professor": "Jones Hinz,J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -23894,8 +23960,8 @@
       "professor": "Jaggar,S.R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -23908,8 +23974,8 @@
       "professor": "Wilson,J.B.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -23922,8 +23988,8 @@
       "professor": "Dewitt,J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -23936,8 +24002,8 @@
       "professor": "Shaw,M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -23970,8 +24036,8 @@
       "professor": "Tellez,K.T.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -24004,7 +24070,7 @@
       "professor": "Bunch,G.",
       "lectures": [
         {
-          "location": null,
+          "location": "",
           "times": [
             {
               "day": "Monday",
@@ -24029,7 +24095,7 @@
       "professor": "Mosqueda,E.",
       "lectures": [
         {
-          "location": null,
+          "location": "",
           "times": [
             {
               "day": "Wednesday",
@@ -24070,7 +24136,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -24083,7 +24149,7 @@
       "professor": "Severance,S.J.",
       "lectures": [
         {
-          "location": null,
+          "location": "",
           "times": [
             {
               "day": "Monday",
@@ -24103,7 +24169,7 @@
       "professor": "Jibrin,R.",
       "lectures": [
         {
-          "location": null,
+          "location": "",
           "times": [
             {
               "day": "Monday",
@@ -24369,7 +24435,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -24383,7 +24449,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -24396,8 +24462,8 @@
       "professor": "Croll,D.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -24410,8 +24476,8 @@
       "professor": "Croll,D.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -24424,8 +24490,8 @@
       "professor": "Dayton,G.H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -24438,8 +24504,8 @@
       "professor": "Dayton,G.H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -24957,8 +25023,8 @@
       "professor": "Benner,C.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -24971,8 +25037,8 @@
       "professor": "Bury,J.T.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -24985,8 +25051,8 @@
       "professor": "Campbell,E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -24999,8 +25065,8 @@
       "professor": "Cheng,W.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -25013,8 +25079,8 @@
       "professor": "Fairbairn,M.P.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -25027,8 +25093,8 @@
       "professor": "Gilbert,G.S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -25041,8 +25107,8 @@
       "professor": "Holl,K.D.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -25055,8 +25121,8 @@
       "professor": "Jinnah,S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -25069,8 +25135,8 @@
       "professor": "Kapuscinski,A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -25083,8 +25149,8 @@
       "professor": "Loik,M.E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -25097,8 +25163,8 @@
       "professor": "Lu,F.E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -25111,8 +25177,8 @@
       "professor": "Montenegro de Wit,M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -25125,8 +25191,8 @@
       "professor": "Philpott,S.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -25139,8 +25205,8 @@
       "professor": "Rajan,S.R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -25153,8 +25219,8 @@
       "professor": "Seto,K.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -25167,8 +25233,8 @@
       "professor": "Wilmers,C.C.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -25181,8 +25247,8 @@
       "professor": "Zhu,K.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -25195,8 +25261,8 @@
       "professor": "Ocampo-Penuela,N.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -25390,7 +25456,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -25404,7 +25470,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -25542,8 +25608,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -25686,8 +25752,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -25901,7 +25967,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -26184,8 +26250,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -26569,7 +26635,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -26658,7 +26724,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -26697,7 +26763,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -27566,7 +27632,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -27580,7 +27646,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -27774,7 +27840,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -27788,7 +27854,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -28137,7 +28203,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -28476,7 +28542,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -28679,8 +28745,8 @@
       "professor": "Toosarvandani,M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -28693,8 +28759,8 @@
       "professor": "Sichel,I.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -28707,8 +28773,8 @@
       "professor": "McGuire,G.L.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -28967,7 +29033,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -28980,8 +29046,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -28995,7 +29061,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -29069,7 +29135,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -29082,8 +29148,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -29406,8 +29472,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -30121,7 +30187,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -30134,8 +30200,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -30193,8 +30259,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -30207,8 +30273,8 @@
       "professor": "Saltikov,C.W.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -30221,8 +30287,8 @@
       "professor": "Kimmey,J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -30235,8 +30301,8 @@
       "professor": "Camps,M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -30250,7 +30316,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -30264,7 +30330,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -30277,8 +30343,8 @@
       "professor": "Chamorro-Garcia,R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -30291,8 +30357,8 @@
       "professor": "Smith,D.R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -30305,8 +30371,8 @@
       "professor": "Stone,V.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -30319,8 +30385,8 @@
       "professor": "Yildiz,F.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -30333,8 +30399,8 @@
       "professor": "Kimmey,J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -31982,8 +32048,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -33106,8 +33172,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -33520,8 +33586,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -33559,8 +33625,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -33573,8 +33639,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -33612,8 +33678,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -34451,8 +34517,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -34485,8 +34551,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -34499,8 +34565,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -34978,8 +35044,8 @@
       "professor": "Profumo,S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -35012,8 +35078,8 @@
       "professor": "Carter,S.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -35027,7 +35093,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -35881,7 +35947,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -36659,8 +36725,8 @@
       "professor": "Hayden,E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -36673,8 +36739,8 @@
       "professor": "Hayden,E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -36973,7 +37039,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -37401,8 +37467,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -37505,8 +37571,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -37609,8 +37675,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -38078,8 +38144,8 @@
       "professor": "Horton,W.Z.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -38092,8 +38158,8 @@
       "professor": "Zheng,X.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -38586,8 +38652,8 @@
       "professor": "Cuthbert,D.L.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -38626,7 +38692,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -39074,8 +39140,8 @@
       "professor": "Shapiro,H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -39088,8 +39154,8 @@
       "professor": "Shapiro,H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -39163,7 +39229,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -39177,7 +39243,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -39321,7 +39387,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -39335,7 +39401,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -39349,7 +39415,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -39443,7 +39509,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -39517,7 +39583,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -39531,7 +39597,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -39680,7 +39746,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -39694,7 +39760,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -39708,7 +39774,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -39722,7 +39788,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -39931,7 +39997,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -39945,7 +40011,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -40009,7 +40075,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -40158,7 +40224,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -40172,7 +40238,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -40566,7 +40632,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -40580,7 +40646,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -40594,7 +40660,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -40608,7 +40674,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -40701,8 +40767,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2222
@@ -40776,7 +40842,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -40815,7 +40881,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -40829,7 +40895,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -40843,7 +40909,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -40987,7 +41053,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2222
@@ -41385,8 +41451,8 @@
       "professor": "Brummell,N.H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -41400,7 +41466,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -41533,8 +41599,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -41548,7 +41614,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -41562,7 +41628,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -41996,7 +42062,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -42010,7 +42076,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -42409,7 +42475,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -42423,7 +42489,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -42437,7 +42503,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -42451,7 +42517,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -42465,7 +42531,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -42479,7 +42545,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -42493,7 +42559,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -42507,7 +42573,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -42521,7 +42587,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -42535,7 +42601,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -42549,7 +42615,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -42563,7 +42629,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -42577,7 +42643,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -42915,8 +42981,8 @@
       "professor": "Nath,S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -43074,8 +43140,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -43508,8 +43574,8 @@
       "professor": "Parsa,M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -43757,8 +43823,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -43851,8 +43917,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -43865,8 +43931,8 @@
       "professor": "Renau Ardevol,J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -43879,8 +43945,8 @@
       "professor": "Obraczka,K.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -43893,8 +43959,8 @@
       "professor": "Qian,C.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -43907,8 +43973,8 @@
       "professor": "Sorensen,T.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -43921,8 +43987,8 @@
       "professor": "Renau Ardevol,J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -43935,8 +44001,8 @@
       "professor": "Maltzahn,C.G.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -43949,8 +44015,8 @@
       "professor": "Long,D.D.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -43963,8 +44029,8 @@
       "professor": "Manduchi,R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -43977,8 +44043,8 @@
       "professor": "Alvaro,P.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -44041,8 +44107,8 @@
       "professor": "Raimondi,P.T.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -44100,8 +44166,8 @@
       "professor": "Croll,D.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -44114,8 +44180,8 @@
       "professor": "Croll,D.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -44239,7 +44305,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -44408,7 +44474,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -44472,7 +44538,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -44711,7 +44777,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -44725,7 +44791,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -44739,7 +44805,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -44753,7 +44819,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -44767,7 +44833,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -44781,7 +44847,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -44795,7 +44861,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -44809,7 +44875,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -44938,7 +45004,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -45002,7 +45068,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -45041,7 +45107,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -45105,7 +45171,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -45918,8 +45984,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -46752,8 +46818,8 @@
       "professor": "Honig,S.E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -46866,8 +46932,8 @@
       "professor": "Desa,S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -47046,7 +47112,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -47314,8 +47380,8 @@
       "professor": "Fehren-Schmitz,L.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -47463,8 +47529,8 @@
       "professor": "Oelze,V.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -47653,7 +47719,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -47796,8 +47862,8 @@
       "professor": "Swensen,E.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -47990,8 +48056,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48495,7 +48561,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48534,7 +48600,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48548,7 +48614,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48656,8 +48722,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48670,8 +48736,8 @@
       "professor": "Kroeker,K.J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48684,8 +48750,8 @@
       "professor": "Raimondi,P.T.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48698,8 +48764,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48777,8 +48843,8 @@
       "professor": "Zavaleta,E.S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48816,8 +48882,8 @@
       "professor": "Pearse,D.E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48831,7 +48897,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48844,8 +48910,8 @@
       "professor": "Alonzo,S.H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48858,8 +48924,8 @@
       "professor": "Carr,M.H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48872,8 +48938,8 @@
       "professor": "Bernardi,G.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48886,8 +48952,8 @@
       "professor": "Costa,D.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48900,8 +48966,8 @@
       "professor": "Kroeker,K.J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48914,8 +48980,8 @@
       "professor": "Palkovacs,E.P.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48928,8 +48994,8 @@
       "professor": "Fox,L.R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48942,8 +49008,8 @@
       "professor": "Alonzo,S.H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48956,8 +49022,8 @@
       "professor": "Mehta,R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48970,8 +49036,8 @@
       "professor": "Kilpatrick,A.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48984,8 +49050,8 @@
       "professor": "Kay,K.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -48998,8 +49064,8 @@
       "professor": "Lyon,B.E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49012,8 +49078,8 @@
       "professor": "Croll,D.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49026,8 +49092,8 @@
       "professor": "Pittermann,J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49040,8 +49106,8 @@
       "professor": "Parker,I.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49054,8 +49120,8 @@
       "professor": "Pogson,G.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49068,8 +49134,8 @@
       "professor": "Raimondi,P.T.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49082,8 +49148,8 @@
       "professor": "Shapiro,B.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49096,8 +49162,8 @@
       "professor": "Potts,D.C.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49110,8 +49176,8 @@
       "professor": "Sinervo,B.R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49124,8 +49190,8 @@
       "professor": "Williams,T.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49138,8 +49204,8 @@
       "professor": "Beltran,R.S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49152,8 +49218,8 @@
       "professor": "Zavaleta,E.S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49166,8 +49232,8 @@
       "professor": "Kilpatrick,A.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49351,7 +49417,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49390,7 +49456,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49478,8 +49544,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49727,8 +49793,8 @@
       "professor": "Hartzog,G.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49816,8 +49882,8 @@
       "professor": "Ares,M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49830,8 +49896,8 @@
       "professor": "Boeger,H.H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49844,8 +49910,8 @@
       "professor": "Chen,B.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49858,8 +49924,8 @@
       "professor": "Zahler,A.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49872,8 +49938,8 @@
       "professor": "Bhalla,N.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49886,8 +49952,8 @@
       "professor": "Feldheim,D.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49900,8 +49966,8 @@
       "professor": "Ackman,J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49914,8 +49980,8 @@
       "professor": "Hartzog,G.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49928,8 +49994,8 @@
       "professor": "Kamakaka,R.T.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49942,8 +50008,8 @@
       "professor": "Jurica,M.S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49956,8 +50022,8 @@
       "professor": "Kellogg,D.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49970,8 +50036,8 @@
       "professor": "Hinck,L.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49984,8 +50050,8 @@
       "professor": "Sanford,J.R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -49998,8 +50064,8 @@
       "professor": "Carpenter,S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -50013,7 +50079,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -50026,8 +50092,8 @@
       "professor": "Arribere,J.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -50040,8 +50106,8 @@
       "professor": "Greider,C.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -50054,8 +50120,8 @@
       "professor": "Ward,J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -50068,8 +50134,8 @@
       "professor": "Strome,S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -50082,8 +50148,8 @@
       "professor": "Sikandar,S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -50096,8 +50162,8 @@
       "professor": "Sullivan,W.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -50110,8 +50176,8 @@
       "professor": "Morozova,O.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -50124,8 +50190,8 @@
       "professor": "Kim,E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -50138,8 +50204,8 @@
       "professor": "Sharma,U.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -50152,8 +50218,8 @@
       "professor": "Zuo,Y.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -50166,8 +50232,8 @@
       "professor": "Wang,Z.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -50330,8 +50396,8 @@
       "professor": "Roland,R.E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -50344,8 +50410,8 @@
       "professor": "Roland,R.E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -50678,8 +50744,8 @@
       "professor": "Braslau,R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -50692,8 +50758,8 @@
       "professor": "Holman,T.R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -50706,8 +50772,8 @@
       "professor": "Oliver,S.R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -50720,8 +50786,8 @@
       "professor": "Crews,P.O.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -50734,8 +50800,8 @@
       "professor": "Mascharak,P.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -51063,8 +51129,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -51078,7 +51144,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -51162,7 +51228,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -51326,7 +51392,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -51674,8 +51740,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -51709,7 +51775,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -51723,7 +51789,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -51737,7 +51803,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -51751,7 +51817,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -51765,7 +51831,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -51779,7 +51845,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -51793,7 +51859,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -51807,7 +51873,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -51891,7 +51957,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -51995,7 +52061,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -52009,7 +52075,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -52103,7 +52169,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -52436,8 +52502,8 @@
       "professor": "Favaloro,T.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -52641,7 +52707,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -52775,7 +52841,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -53458,8 +53524,8 @@
       "professor": "Zachos,J.C.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -53547,8 +53613,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -53632,7 +53698,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -53671,7 +53737,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -53740,7 +53806,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -53839,7 +53905,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -54013,7 +54079,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -55027,7 +55093,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -55275,8 +55341,8 @@
       "professor": "Dewitt,J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -55289,8 +55355,8 @@
       "professor": "Jaggar,S.R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -55364,7 +55430,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -55497,8 +55563,8 @@
       "professor": "Bartlett,L.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -55646,8 +55712,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -55735,8 +55801,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -55875,7 +55941,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56098,8 +56164,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56367,8 +56433,8 @@
       "professor": "Benner,C.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56381,8 +56447,8 @@
       "professor": "Bury,J.T.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56395,8 +56461,8 @@
       "professor": "Campbell,E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56409,8 +56475,8 @@
       "professor": "Cheng,W.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56423,8 +56489,8 @@
       "professor": "Fairbairn,M.P.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56437,8 +56503,8 @@
       "professor": "Gilbert,G.S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56451,8 +56517,8 @@
       "professor": "Holl,K.D.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56465,8 +56531,8 @@
       "professor": "Jinnah,S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56479,8 +56545,8 @@
       "professor": "Kapuscinski,A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56493,8 +56559,8 @@
       "professor": "Loik,M.E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56507,8 +56573,8 @@
       "professor": "Lu,F.E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56521,8 +56587,8 @@
       "professor": "Montenegro de Wit,M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56535,8 +56601,8 @@
       "professor": "Philpott,S.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56549,8 +56615,8 @@
       "professor": "Rajan,S.R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56563,8 +56629,8 @@
       "professor": "Seto,K.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56577,8 +56643,8 @@
       "professor": "Wilmers,C.C.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56591,8 +56657,8 @@
       "professor": "Zhu,K.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56605,8 +56671,8 @@
       "professor": "Ocampo-Penuela,N.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56619,8 +56685,8 @@
       "professor": "Haddad,B.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56814,7 +56880,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56828,7 +56894,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -56892,7 +56958,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -57050,8 +57116,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -58155,7 +58221,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -58199,7 +58265,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -58267,8 +58333,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -59207,7 +59273,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -59221,7 +59287,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -59290,7 +59356,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -59354,7 +59420,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -59393,7 +59459,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -60012,7 +60078,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -60250,8 +60316,8 @@
       "professor": "Law,J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -60264,8 +60330,8 @@
       "professor": "Van Handel,N.J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -60278,8 +60344,8 @@
       "professor": "Wagers,M.W.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -60393,7 +60459,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -60406,8 +60472,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -60591,7 +60657,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -60605,7 +60671,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -60619,7 +60685,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -60693,7 +60759,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -60707,7 +60773,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -61635,8 +61701,8 @@
       "professor": "Saltikov,C.W.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -61649,8 +61715,8 @@
       "professor": "Kimmey,J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -61663,8 +61729,8 @@
       "professor": "Camps,M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -61678,7 +61744,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -61691,8 +61757,8 @@
       "professor": "Patnode,M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -61705,8 +61771,8 @@
       "professor": "Chamorro-Garcia,R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -61719,8 +61785,8 @@
       "professor": "Smith,D.R.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -61733,8 +61799,8 @@
       "professor": "Stone,V.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -61747,8 +61813,8 @@
       "professor": "Yildiz,F.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -61761,8 +61827,8 @@
       "professor": "Kimmey,J.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -62020,8 +62086,8 @@
       "professor": "Lanam,F.S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -62299,8 +62365,8 @@
       "professor": "Fiore,G.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -63199,7 +63265,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -63317,8 +63383,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -63667,7 +63733,7 @@
       "lectures": [
         {
           "location": "Humanities 1 400",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -64010,8 +64076,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -65294,8 +65360,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -65813,8 +65879,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -65977,8 +66043,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -65991,8 +66057,8 @@
       "professor": "Profumo,S.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -66025,8 +66091,8 @@
       "professor": "Carter,S.A.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -66039,8 +66105,8 @@
       "professor": "Smith,D.M.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -67403,8 +67469,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -67983,7 +68049,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -68161,8 +68227,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -69095,8 +69161,8 @@
       "professor": "Horton,W.Z.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -69109,8 +69175,8 @@
       "professor": "Zheng,X.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -69248,8 +69314,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -69577,8 +69643,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -69771,8 +69837,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -70275,8 +70341,8 @@
       "professor": "Edmunds,K.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -70385,7 +70451,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -70498,8 +70564,8 @@
       "professor": "Lee,C.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -70707,8 +70773,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -70766,8 +70832,8 @@
       "professor": "Shapiro,H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -70780,8 +70846,8 @@
       "professor": "Shapiro,H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -70794,8 +70860,8 @@
       "professor": "Shapiro,H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -71084,7 +71150,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -71098,7 +71164,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -71172,7 +71238,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -71186,7 +71252,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -71225,7 +71291,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -71529,7 +71595,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -71543,7 +71609,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -71582,7 +71648,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -71596,7 +71662,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -71610,7 +71676,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -71989,7 +72055,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72003,7 +72069,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72292,7 +72358,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72306,7 +72372,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72320,7 +72386,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72334,7 +72400,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72383,7 +72449,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72397,7 +72463,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72411,7 +72477,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72425,7 +72491,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72439,7 +72505,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72562,8 +72628,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72576,8 +72642,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72591,7 +72657,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72605,7 +72671,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72644,7 +72710,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72658,7 +72724,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72672,7 +72738,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72686,7 +72752,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72700,7 +72766,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72714,7 +72780,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72728,7 +72794,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72852,7 +72918,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -72866,7 +72932,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2220
@@ -73295,7 +73361,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -73509,7 +73575,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -73913,7 +73979,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -73926,8 +73992,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -73941,7 +74007,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -74219,8 +74285,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -74278,8 +74344,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -74292,8 +74358,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -74307,7 +74373,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -74321,7 +74387,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -74335,7 +74401,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -74349,7 +74415,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -74363,7 +74429,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -74377,7 +74443,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -74391,7 +74457,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -74405,7 +74471,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -74419,7 +74485,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -74433,7 +74499,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -74447,7 +74513,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -74461,7 +74527,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -74554,8 +74620,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -74814,7 +74880,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -75418,7 +75484,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -75457,7 +75523,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -75915,8 +75981,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -75955,7 +76021,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -75969,7 +76035,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -75983,7 +76049,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -75997,7 +76063,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76011,7 +76077,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76025,7 +76091,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76039,7 +76105,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76053,7 +76119,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76067,7 +76133,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76251,7 +76317,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76265,7 +76331,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76359,7 +76425,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76398,7 +76464,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76437,7 +76503,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76531,7 +76597,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76600,7 +76666,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76639,7 +76705,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76813,7 +76879,7 @@
         },
         {
           "location": "Remote Meeting",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76852,7 +76918,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76866,7 +76932,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76880,7 +76946,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76894,7 +76960,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76908,7 +76974,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76922,7 +76988,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -76936,7 +77002,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -77060,7 +77126,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -77074,7 +77140,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -77143,7 +77209,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -77157,7 +77223,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -77275,8 +77341,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -77315,7 +77381,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -77459,7 +77525,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -77538,7 +77604,7 @@
         },
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -77621,8 +77687,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -78836,7 +78902,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -78950,7 +79016,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -79059,7 +79125,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -79098,7 +79164,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -79112,7 +79178,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -79325,8 +79391,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -79450,7 +79516,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -79548,8 +79614,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -79582,8 +79648,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -79597,7 +79663,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -79841,7 +79907,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -79854,8 +79920,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -80129,7 +80195,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -80268,7 +80334,7 @@
       "lectures": [
         {
           "location": "Ocean Health 118",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -80282,7 +80348,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -80481,7 +80547,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -80730,7 +80796,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -80904,7 +80970,7 @@
       "lectures": [
         {
           "location": "CoastBio 203",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -80918,7 +80984,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -80932,7 +80998,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -80946,7 +81012,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -80960,7 +81026,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -80974,7 +81040,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -80988,7 +81054,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81002,7 +81068,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81016,7 +81082,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81030,7 +81096,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81044,7 +81110,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81058,7 +81124,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81072,7 +81138,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81086,7 +81152,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81100,7 +81166,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81114,7 +81180,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81128,7 +81194,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81142,7 +81208,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81156,7 +81222,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81170,7 +81236,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81184,7 +81250,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81198,7 +81264,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81212,7 +81278,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81226,7 +81292,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81240,7 +81306,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81414,7 +81480,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81473,7 +81539,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81586,8 +81652,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81620,8 +81686,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81654,8 +81720,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81713,8 +81779,8 @@
       "professor": "Zuniga,M.C.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81813,7 +81879,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81827,7 +81893,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81841,7 +81907,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81855,7 +81921,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81869,7 +81935,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81883,7 +81949,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81897,7 +81963,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81911,7 +81977,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81925,7 +81991,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81939,7 +82005,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81953,7 +82019,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81967,7 +82033,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81981,7 +82047,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -81995,7 +82061,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82009,7 +82075,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82023,7 +82089,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82037,7 +82103,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82051,7 +82117,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82065,7 +82131,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82079,7 +82145,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82093,7 +82159,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82107,7 +82173,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82121,7 +82187,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82135,7 +82201,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82149,7 +82215,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82163,7 +82229,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82177,7 +82243,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82381,7 +82447,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82395,7 +82461,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82559,7 +82625,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82763,7 +82829,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82777,7 +82843,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82791,7 +82857,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82805,7 +82871,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -82819,7 +82885,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -83502,8 +83568,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -83516,8 +83582,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -83606,7 +83672,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -84064,8 +84130,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -84078,8 +84144,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -84117,8 +84183,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -84157,7 +84223,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -84171,7 +84237,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -84185,7 +84251,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -84224,7 +84290,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -84238,7 +84304,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -84252,7 +84318,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -84445,8 +84511,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -84700,7 +84766,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -84714,7 +84780,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -84728,7 +84794,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -84742,7 +84808,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -84756,7 +84822,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -84769,8 +84835,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -84784,7 +84850,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -84798,7 +84864,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -84812,7 +84878,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -85560,8 +85626,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -85710,7 +85776,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -85769,7 +85835,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -85782,8 +85848,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -86391,8 +86457,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -86405,8 +86471,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -86419,8 +86485,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -86824,7 +86890,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -86867,8 +86933,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -87241,8 +87307,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -87415,8 +87481,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -87429,8 +87495,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -87564,7 +87630,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -87768,7 +87834,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -87892,7 +87958,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -89211,7 +89277,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -89335,7 +89401,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -89499,7 +89565,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -89648,7 +89714,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -90026,8 +90092,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -90115,8 +90181,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -90154,7 +90220,7 @@
       "professor": "Lashaw,A.",
       "lectures": [
         {
-          "location": null,
+          "location": "",
           "times": [
             {
               "day": "Tuesday",
@@ -90179,8 +90245,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -90254,7 +90320,7 @@
         },
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -90403,7 +90469,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -90587,7 +90653,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -90855,8 +90921,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91120,7 +91186,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91514,7 +91580,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91528,7 +91594,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91542,7 +91608,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91556,7 +91622,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91570,7 +91636,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91584,7 +91650,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91598,7 +91664,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91612,7 +91678,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91626,7 +91692,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91640,7 +91706,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91654,7 +91720,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91668,7 +91734,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91682,7 +91748,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91696,7 +91762,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91710,7 +91776,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91724,7 +91790,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91738,7 +91804,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91752,7 +91818,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91766,7 +91832,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91905,7 +91971,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91918,8 +91984,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -91983,7 +92049,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -92022,7 +92088,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -92136,7 +92202,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -92379,8 +92445,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -92533,8 +92599,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -92622,8 +92688,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -92656,8 +92722,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -93186,7 +93252,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -93200,7 +93266,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -93214,7 +93280,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -93227,8 +93293,8 @@
       "professor": "Crutchfield,A.E.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -93242,7 +93308,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -93256,7 +93322,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -93270,7 +93336,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -93369,7 +93435,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -93383,7 +93449,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -93422,7 +93488,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -93461,7 +93527,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -93500,7 +93566,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -93514,7 +93580,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -93528,7 +93594,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -94761,8 +94827,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -94946,7 +95012,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -95005,7 +95071,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -95019,7 +95085,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -95063,7 +95129,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -95102,7 +95168,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -95296,7 +95362,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         },
         {
           "location": "Soc Sci 2 071",
@@ -95559,8 +95625,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -95704,7 +95770,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -95743,7 +95809,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -95912,7 +95978,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -95926,7 +95992,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -95940,7 +96006,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -96049,7 +96115,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -96303,7 +96369,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -96317,7 +96383,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -96331,7 +96397,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -96405,7 +96471,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -96419,7 +96485,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -97212,8 +97278,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -97226,8 +97292,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -97240,8 +97306,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -97769,8 +97835,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -97874,7 +97940,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -97888,7 +97954,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -97902,7 +97968,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -97916,7 +97982,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -97930,7 +97996,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -97944,7 +98010,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -97958,7 +98024,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -97972,7 +98038,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -97986,7 +98052,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -98000,7 +98066,7 @@
       "lectures": [
         {
           "location": "PhysSciences 240",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -98173,8 +98239,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -98263,7 +98329,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -98547,7 +98613,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -98561,7 +98627,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -99499,8 +99565,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -99513,8 +99579,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -99527,8 +99593,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -99541,8 +99607,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -99615,8 +99681,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -99629,8 +99695,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -99798,8 +99864,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -99837,8 +99903,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -100186,8 +100252,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -100226,7 +100292,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -100440,7 +100506,7 @@
       "lectures": [
         {
           "location": "Humanities 1 400",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -100454,7 +100520,7 @@
       "lectures": [
         {
           "location": "Humanities 1 400",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -100487,8 +100553,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -100501,8 +100567,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -100565,8 +100631,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -100579,8 +100645,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -100593,8 +100659,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -100607,8 +100673,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -100621,8 +100687,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -100635,8 +100701,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -100809,8 +100875,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -100823,8 +100889,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -100837,8 +100903,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -100901,8 +100967,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -100935,8 +101001,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -101049,8 +101115,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -101063,8 +101129,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -101077,8 +101143,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -101191,8 +101257,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -101255,8 +101321,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -101269,8 +101335,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -102063,8 +102129,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -102077,8 +102143,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -102151,8 +102217,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -102225,8 +102291,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -102239,8 +102305,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -102779,7 +102845,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -102813,7 +102879,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -102827,7 +102893,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -103296,7 +103362,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -104039,8 +104105,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -104053,8 +104119,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -104067,8 +104133,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -104476,8 +104542,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -105186,7 +105252,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -105455,7 +105521,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -105688,8 +105754,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -105972,8 +106038,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -106161,8 +106227,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -106486,7 +106552,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -106500,7 +106566,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -106723,8 +106789,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -106757,8 +106823,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -107076,8 +107142,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -107090,8 +107156,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -107409,8 +107475,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -107423,8 +107489,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -107437,8 +107503,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -107451,8 +107517,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -107576,7 +107642,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -107790,7 +107856,7 @@
       "lectures": [
         {
           "location": "TA Mainstage A100",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -107924,7 +107990,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -108012,8 +108078,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -108186,8 +108252,8 @@
       "professor": "Shapiro,H.",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -108201,7 +108267,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -108215,7 +108281,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -108228,8 +108294,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -108243,7 +108309,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -108267,7 +108333,7 @@
         },
         {
           "location": "Remote Meeting",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -108466,7 +108532,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -108480,7 +108546,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -108688,8 +108754,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -108927,8 +108993,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -109072,7 +109138,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -109086,7 +109152,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -109295,7 +109361,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -109309,7 +109375,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -109323,7 +109389,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -109337,7 +109403,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -109411,7 +109477,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -109425,7 +109491,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -109439,7 +109505,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -109538,7 +109604,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -109552,7 +109618,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -109590,8 +109656,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -109605,7 +109671,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -109619,7 +109685,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -109633,7 +109699,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -109646,8 +109712,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2218
@@ -109751,7 +109817,7 @@
         },
         {
           "location": "Remote Meeting",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -109775,7 +109841,7 @@
         },
         {
           "location": "Remote Meeting",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2218
@@ -109968,8 +110034,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110033,7 +110099,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110047,7 +110113,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110061,7 +110127,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110100,7 +110166,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110114,7 +110180,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110127,8 +110193,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110192,7 +110258,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110231,7 +110297,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110245,7 +110311,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110284,7 +110350,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110383,7 +110449,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110422,7 +110488,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110436,7 +110502,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110550,7 +110616,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110619,7 +110685,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110633,7 +110699,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110647,7 +110713,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110686,7 +110752,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110700,7 +110766,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110714,7 +110780,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110753,7 +110819,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110766,8 +110832,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110856,7 +110922,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -110985,7 +111051,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111069,7 +111135,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111173,7 +111239,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111187,7 +111253,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111201,7 +111267,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111215,7 +111281,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111229,7 +111295,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111273,7 +111339,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111312,7 +111378,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111351,7 +111417,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111364,8 +111430,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111378,8 +111444,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111417,8 +111483,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111432,7 +111498,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111446,7 +111512,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111460,7 +111526,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111499,7 +111565,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111513,7 +111579,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111632,7 +111698,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111696,7 +111762,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111735,7 +111801,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111819,7 +111885,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111833,7 +111899,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111847,7 +111913,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111861,7 +111927,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111920,7 +111986,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111934,7 +112000,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -111948,7 +112014,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -112152,7 +112218,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -112226,7 +112292,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -112575,7 +112641,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -112589,7 +112655,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -112678,7 +112744,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -112692,7 +112758,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -112706,7 +112772,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -112720,7 +112786,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -112914,7 +112980,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -112928,7 +112994,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113011,8 +113077,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113051,7 +113117,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113065,7 +113131,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113079,7 +113145,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113118,7 +113184,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113132,7 +113198,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113196,7 +113262,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113210,7 +113276,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113224,7 +113290,7 @@
       "lectures": [
         {
           "location": "TBD In Person",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113263,7 +113329,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113277,7 +113343,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113321,7 +113387,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113335,7 +113401,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113539,7 +113605,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113823,7 +113889,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113837,7 +113903,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113851,7 +113917,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113865,7 +113931,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113879,7 +113945,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113893,7 +113959,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113907,7 +113973,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113921,7 +113987,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113935,7 +114001,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113949,7 +114015,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113963,7 +114029,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -113977,7 +114043,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114011,7 +114077,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114074,8 +114140,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114114,7 +114180,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114153,7 +114219,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114192,7 +114258,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114331,7 +114397,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114345,7 +114411,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114459,7 +114525,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114473,7 +114539,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114487,7 +114553,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114570,8 +114636,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114665,7 +114731,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114679,7 +114745,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114693,7 +114759,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114707,7 +114773,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114721,7 +114787,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114835,7 +114901,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114889,7 +114955,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114903,7 +114969,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114917,7 +114983,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114930,8 +114996,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114945,7 +115011,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114959,7 +115025,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114973,7 +115039,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -114987,7 +115053,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -115000,8 +115066,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -115015,7 +115081,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -115129,7 +115195,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -115143,7 +115209,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -115182,7 +115248,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -115216,7 +115282,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -115280,7 +115346,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -115294,7 +115360,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -115573,7 +115639,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -115587,7 +115653,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -115601,7 +115667,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -115615,7 +115681,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -115659,7 +115725,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -115733,7 +115799,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -115747,7 +115813,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -115761,7 +115827,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -115775,7 +115841,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116179,7 +116245,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116193,7 +116259,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116206,8 +116272,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116221,7 +116287,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116360,7 +116426,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116374,7 +116440,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116387,8 +116453,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116421,8 +116487,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116436,7 +116502,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116535,7 +116601,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116549,7 +116615,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116593,7 +116659,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116607,7 +116673,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116620,8 +116686,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116634,8 +116700,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116674,7 +116740,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116688,7 +116754,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116701,8 +116767,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116716,7 +116782,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116760,7 +116826,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116799,7 +116865,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -116812,8 +116878,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -117097,7 +117163,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -117211,7 +117277,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -117225,7 +117291,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -117239,7 +117305,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -117253,7 +117319,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -117292,7 +117358,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -117486,7 +117552,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -117575,7 +117641,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -117739,7 +117805,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -117858,7 +117924,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -117922,7 +117988,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -117936,7 +118002,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118100,7 +118166,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118114,7 +118180,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118127,8 +118193,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118222,7 +118288,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118236,7 +118302,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118250,7 +118316,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118264,7 +118330,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118378,7 +118444,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118392,7 +118458,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118506,7 +118572,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118520,7 +118586,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118534,7 +118600,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118548,7 +118614,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118562,7 +118628,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118575,8 +118641,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118589,8 +118655,8 @@
       "professor": "Staff",
       "lectures": [
         {
-          "location": null,
-          "times": null
+          "location": "",
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118629,7 +118695,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118693,7 +118759,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118707,7 +118773,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118771,7 +118837,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118785,7 +118851,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118799,7 +118865,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118813,7 +118879,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118827,7 +118893,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118841,7 +118907,7 @@
       "lectures": [
         {
           "location": "Online",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118855,7 +118921,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118869,7 +118935,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214
@@ -118883,7 +118949,7 @@
       "lectures": [
         {
           "location": "Remote Instruction",
-          "times": null
+          "times": []
         }
       ],
       "termcode": 2214


### PR DESCRIPTION
Implemented GET /courses and /subjects endpoint.

/subjects takes an optional query parameter to filter by term

/courses takes two required query parameters to filter by term and subject (making it not optional causes too many courses to be returned).

Important additional changes:
returned lectures for each course is an array since there can be multiple lecture schedules
courseName field changed to name, since context provides the name belongs to a course